### PR TITLE
Add sample Sentry SwiftUI e-commerce demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
 # Swift_iOS_demonstration
 Simple test of Sentry’s Cocoa SDK in Swift environment
+
+## Sentry E-Commerce Sample App
+
+This repository contains a minimal SwiftUI iOS application demonstrating Sentry error monitoring, performance tracing, profiling and mobile session replay. The app loads a catalog with an intentional delay, lets users add items to a cart, and triggers an error on checkout to showcase Sentry's reporting.
+
+Open `SentryECommerceSampleApp.swift` to configure your DSN and launch the app.

--- a/SentryECommerceSampleApp/Managers/CartManager.swift
+++ b/SentryECommerceSampleApp/Managers/CartManager.swift
@@ -1,0 +1,20 @@
+import Foundation
+import Sentry
+
+final class CartManager: ObservableObject {
+    @Published private(set) var items: [Product] = []
+
+    func add(_ product: Product) {
+        let span = SentrySDK.startTransaction(name: "Add to Cart", operation: "cart.add")
+        items.append(product)
+        span.finish()
+    }
+
+    func checkout() {
+        let span = SentrySDK.startTransaction(name: "Checkout", operation: "cart.checkout")
+        // Intentionally trigger an error when checkout is attempted
+        let error = NSError(domain: "SampleCheckout", code: 999, userInfo: [NSLocalizedDescriptionKey: "Checkout failed intentionally"])
+        SentrySDK.capture(error: error)
+        span.finish(status: .internalError)
+    }
+}

--- a/SentryECommerceSampleApp/Models/Product.swift
+++ b/SentryECommerceSampleApp/Models/Product.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+struct Product: Identifiable {
+    let id: UUID = UUID()
+    let name: String
+    let price: Double
+}
+
+extension Product {
+    static let sampleCatalog: [Product] = [
+        Product(name: "Widget", price: 9.99),
+        Product(name: "Gadget", price: 12.49),
+        Product(name: "Doohickey", price: 7.25)
+    ]
+}

--- a/SentryECommerceSampleApp/SentryECommerceSampleApp.swift
+++ b/SentryECommerceSampleApp/SentryECommerceSampleApp.swift
@@ -1,0 +1,27 @@
+import SwiftUI
+import Sentry
+
+@main
+struct SentryECommerceSampleApp: App {
+    init() {
+        SentrySDK.start { options in
+            options.dsn = "<INSERT_DSN_HERE>"
+            options.tracesSampleRate = 1.0
+            options.profilesSampleRate = 1.0
+            options.enableAutoSessionTracking = true
+            options.enableSwizzling = true
+            options.attachScreenshot = true
+            options.attachViewHierarchy = true
+            options.recordingSampleRate = 1.0
+        }
+    }
+    
+    @StateObject private var cartManager = CartManager()
+    
+    var body: some Scene {
+        WindowGroup {
+            CatalogView()
+                .environmentObject(cartManager)
+        }
+    }
+}

--- a/SentryECommerceSampleApp/Views/CartView.swift
+++ b/SentryECommerceSampleApp/Views/CartView.swift
@@ -1,0 +1,28 @@
+import SwiftUI
+import Sentry
+
+struct CartView: View {
+    @EnvironmentObject private var cartManager: CartManager
+    @State private var navigateToCheckout = false
+
+    var body: some View {
+        List {
+            ForEach(cartManager.items) { item in
+                Text(item.name)
+            }
+        }
+        .navigationTitle("Cart")
+        .toolbar {
+            Button("Checkout") {
+                navigateToCheckout = true
+                cartManager.checkout()
+            }
+        }
+        .background(
+            NavigationLink(
+                destination: CheckoutView(),
+                isActive: $navigateToCheckout
+            ) { EmptyView() }
+        )
+    }
+}

--- a/SentryECommerceSampleApp/Views/CatalogView.swift
+++ b/SentryECommerceSampleApp/Views/CatalogView.swift
@@ -1,0 +1,40 @@
+import SwiftUI
+import Sentry
+
+struct CatalogView: View {
+    @State private var products: [Product] = []
+    @EnvironmentObject private var cartManager: CartManager
+
+    var body: some View {
+        NavigationView {
+            List(products) { product in
+                HStack {
+                    VStack(alignment: .leading) {
+                        Text(product.name)
+                        Text("$\(product.price, specifier: "%.2f")")
+                    }
+                    Spacer()
+                    Button("Add") {
+                        cartManager.add(product)
+                    }
+                }
+            }
+            .navigationTitle("Catalog")
+            .toolbar {
+                NavigationLink(destination: CartView()) {
+                    Image(systemName: "cart")
+                }
+            }
+        }
+        .onAppear(perform: loadCatalog)
+    }
+
+    private func loadCatalog() {
+        let span = SentrySDK.startTransaction(name: "Load Catalog", operation: "catalog.load")
+        // intentionally slow load
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
+            self.products = Product.sampleCatalog
+            span.finish()
+        }
+    }
+}

--- a/SentryECommerceSampleApp/Views/CheckoutView.swift
+++ b/SentryECommerceSampleApp/Views/CheckoutView.swift
@@ -1,0 +1,21 @@
+import SwiftUI
+
+struct CheckoutView: View {
+    var body: some View {
+        VStack(alignment: .leading, spacing: 20) {
+            Text("Shipping")
+                .font(.headline)
+            Text("John Doe")
+            Text("123 Main St")
+            Text("City, State 00000")
+
+            Text("Billing")
+                .font(.headline)
+            Text("Visa **** 4242")
+
+            Spacer()
+        }
+        .padding()
+        .navigationTitle("Review Order")
+    }
+}


### PR DESCRIPTION
## Summary
- add a basic SwiftUI e-commerce app demo
- instrument Sentry for errors, performance, profiling and replay
- update README with instructions

## Testing
- `swiftc --version`


------
https://chatgpt.com/codex/tasks/task_e_686614f8d83483269e0bf3e01bfc852d